### PR TITLE
Update victory-container.js

### DIFF
--- a/packages/victory-core/src/victory-container/victory-container.js
+++ b/packages/victory-core/src/victory-container/victory-container.js
@@ -66,7 +66,7 @@ export default class VictoryContainer extends React.Component {
       this.containerRef = props.containerRef || container;
       return container;
     };
-    this.shouldHandleWheel = props.events && props.events.onWheel;
+    this.shouldHandleWheel = props && props.events && props.events.onWheel;
     if (this.shouldHandleWheel) {
       this.handleWheel = (e) => e.preventDefault();
     }


### PR DESCRIPTION
fix createContainer with zoom and voronai - props ends up undefined at line 69 and throws an error "props.events - can't get events of undefined"